### PR TITLE
 Unify stage coordinates' units across instamatic

### DIFF
--- a/instamaticServer/TEMController/microscope.py
+++ b/instamaticServer/TEMController/microscope.py
@@ -3,10 +3,10 @@ from utils.config import config
 _conf = config()
 _tem_interfaces = ('simulate', 'tecnai')
 
-__all__ = ['Microscope', 'get_tem']
+__all__ = ['get_microscope', 'get_microscope_class']
 
 
-def get_tem(interface: str):
+def get_microscope_class(interface: str):
     """Grab the tem class with the given 'interface'."""
 
     if interface == 'simulate':
@@ -19,7 +19,7 @@ def get_tem(interface: str):
     return cls
 
 
-def Microscope(name: str = None):
+def get_microscope(name: str = None):
     """Generic class to load microscope interface class.
 
     name: str
@@ -35,7 +35,7 @@ def Microscope(name: str = None):
         interface = _conf.micr_interface
         name = _conf.default_settings['microscope']
 
-    cls = get_tem(interface=interface)
+    cls = get_microscope_class(interface=interface)
     tem = cls(name=name)
 
     return tem

--- a/instamaticServer/TEMController/simu_microscope.py
+++ b/instamaticServer/TEMController/simu_microscope.py
@@ -1,9 +1,11 @@
 import random
 import time
-from typing import Tuple
+from typing import Optional, Tuple, Union
 
+from .typing import StagePositionTuple, float_deg, int_nm
 from utils.exceptions import TEMValueError
 from utils.config import config
+
 
 NTRLMAPPING = {
     'GUN1': 0,
@@ -167,7 +169,7 @@ class SimuMicroscope:
         for key in ('a', 'b', 'x', 'y', 'z'):
             self._stage_dict[key]['speed'] = 2**32
 
-    def _StagePositionSetter(self, var: str, val: float) -> None:
+    def _StagePositionSetter(self, var: str, val: Union[int_nm, float_deg]) -> None:
         """General stage position setter, models stage movement speed."""
         d = self._stage_dict[var]
         current = d['current']
@@ -179,7 +181,7 @@ class SimuMicroscope:
         d['t0'] = time.perf_counter()
         d['direction'] = direction
 
-    def _StagePositionGetter(self, var: str) -> float:
+    def _StagePositionGetter(self, var: str) -> Union[int_nm, float_deg]:
         """General stage position getter, models stage movement speed."""
         d = self._stage_dict[var]
         is_moving = d['is_moving']
@@ -203,43 +205,43 @@ class SimuMicroscope:
         return ret
 
     @property
-    def StagePosition_a(self):
+    def StagePosition_a(self) -> float_deg:
         return self._StagePositionGetter('a')
 
     @StagePosition_a.setter
-    def StagePosition_a(self, value):
+    def StagePosition_a(self, value: float_deg) -> None:
         self._StagePositionSetter('a', value)
 
     @property
-    def StagePosition_b(self):
+    def StagePosition_b(self) -> float_deg:
         return self._StagePositionGetter('b')
 
     @StagePosition_b.setter
-    def StagePosition_b(self, value):
+    def StagePosition_b(self, value: float_deg) -> None:
         self._StagePositionSetter('b', value)
 
     @property
-    def StagePosition_x(self):
+    def StagePosition_x(self) -> int_nm:
         return self._StagePositionGetter('x')
 
     @StagePosition_x.setter
-    def StagePosition_x(self, value):
+    def StagePosition_x(self, value: int_nm) -> None:
         self._StagePositionSetter('x', value)
 
     @property
-    def StagePosition_y(self):
+    def StagePosition_y(self) -> int_nm:
         return self._StagePositionGetter('y')
 
     @StagePosition_y.setter
-    def StagePosition_y(self, value):
+    def StagePosition_y(self, value: int_nm) -> None:
         self._StagePositionSetter('y', value)
 
     @property
-    def StagePosition_z(self):
+    def StagePosition_z(self) -> int_nm:
         return self._StagePositionGetter('z')
 
     @StagePosition_z.setter
-    def StagePosition_z(self, value):
+    def StagePosition_z(self, value: int_nm) -> None:
         self._StagePositionSetter('z', value)
 
     @property
@@ -389,8 +391,9 @@ class SimuMicroscope:
         self.ImageShift2_x = x
         self.ImageShift2_y = y
 
-    def getStagePosition(self) -> Tuple[int, int, int, int, int]:
-        return self.StagePosition_x, self.StagePosition_y, self.StagePosition_z, self.StagePosition_a, self.StagePosition_b
+    def getStagePosition(self) -> StagePositionTuple:
+        return (self.StagePosition_x, self.StagePosition_y, self.StagePosition_z,
+                self.StagePosition_a, self.StagePosition_b)
 
     def isStageMoving(self) -> bool:
         self.getStagePosition()  # trigger update of self._is_moving
@@ -401,32 +404,32 @@ class SimuMicroscope:
         while self.isStageMoving():
             time.sleep(delay)
 
-    def setStageX(self, value: int, wait: bool = True):
+    def setStageX(self, value: int_nm, wait: bool = True) -> None:
         self.StagePosition_x = value
         if wait:
             self.waitForStage()
 
-    def setStageY(self, value: int, wait: bool = True):
+    def setStageY(self, value: int_nm, wait: bool = True) -> None:
         self.StagePosition_y = value
         if wait:
             self.waitForStage()
 
-    def setStageZ(self, value: int, wait: bool = True):
+    def setStageZ(self, value: int_nm, wait: bool = True) -> None:
         self.StagePosition_z = value
         if wait:
             self.waitForStage()
 
-    def setStageA(self, value: int, wait: bool = True):
+    def setStageA(self, value: float_deg, wait: bool = True) -> None:
         self.StagePosition_a = value
         if wait:
             self.waitForStage()
 
-    def setStageB(self, value: int, wait: bool = True):
+    def setStageB(self, value: float_deg, wait: bool = True) -> None:
         self.StagePosition_b = value
         if wait:
             self.waitForStage()
 
-    def setStageXY(self, x: int, y: int, wait: bool = True):
+    def setStageXY(self, x: int_nm, y: int_nm, wait: bool = True) -> None:
         self.StagePosition_x = x
         self.StagePosition_y = y
         if wait:
@@ -435,7 +438,16 @@ class SimuMicroscope:
     def stopStage(self):
         pass
 
-    def setStagePosition(self, x: int = None, y: int = None, z: int = None, a: int = None, b: int = None, speed: float = -1, wait: bool = True):
+    def setStagePosition(
+            self,
+            x: Optional[int_nm] = None,
+            y: Optional[int_nm] = None,
+            z: Optional[int_nm] = None,
+            a: Optional[float_deg] = None,
+            b: Optional[float_deg] = None,
+            wait: bool = True,
+            speed: float = -1,
+    ) -> None:
         if z is not None:
             self.setStageZ(z, wait=wait)
         if a is not None:

--- a/instamaticServer/TEMController/tecnai_microscope.py
+++ b/instamaticServer/TEMController/tecnai_microscope.py
@@ -82,11 +82,11 @@ class TecnaiMicroscope(metaclass=Singleton):
         """Return TEM-Holder type as enum constant."""
         return self._tem.Stage.Holder
 
-    def getStagePosition(self) -> (float, float, float, float, float):
-        """Return Stageposition x, y, z in microns and alpha(a), beta(b) in degs."""
-        x = self._tem.Stage.Position.X * 1e6
-        y = self._tem.Stage.Position.Y * 1e6
-        z = self._tem.Stage.Position.Z * 1e6
+    def getStagePosition(self) -> StagePositionTuple:
+        """Return x, y, z in nanometers (used to be microns), angles in deg."""
+        x = self._tem.Stage.Position.X * 1e9
+        y = self._tem.Stage.Position.Y * 1e9
+        z = self._tem.Stage.Position.Z * 1e9
         A = self._tem.Stage.Position.A / pi * 180
         B = self._tem.Stage.Position.B / pi * 180
         return x, y, z, A, B
@@ -142,13 +142,13 @@ class TecnaiMicroscope(metaclass=Singleton):
             enable_B = True
 
         if x is not None and enable_stage:
-            pos.X = x * 1e-6
+            pos.X = x * 1e-9
             axis = axis | self._tem_constant.StageAxes['axisX']
         if y is not None and enable_stage:
-            pos.Y = y * 1e-6
+            pos.Y = y * 1e-9
             axis = axis | self._tem_constant.StageAxes['axisY']
         if z is not None and enable_stage:
-            pos.Z = z * 1e-6
+            pos.Z = z * 1e-9
             axis = axis | self._tem_constant.StageAxes['axisZ']
         if a is not None and enable_stage:
             pos.A = a / 180 * pi

--- a/instamaticServer/TEMController/tecnai_microscope.py
+++ b/instamaticServer/TEMController/tecnai_microscope.py
@@ -3,10 +3,13 @@ import logging
 import time
 import comtypes.client
 from math import pi
+from typing import Optional
 
+from .typing import StagePositionTuple, float_deg, int_nm
 from utils.exceptions import FEIValueError, TEMCommunicationError
 from utils.config import config
 from TEMController.tecnai_stage_thread import TecnaiStageThread
+
 
 _FUNCTION_MODES = {1: 'lowmag', 2: 'mag1', 3: 'samag', 4: 'mag2', 5: 'LAD', 6: 'diff'}
 
@@ -124,9 +127,17 @@ class TecnaiMicroscope(metaclass=Singleton):
                     
         return False
            
-    def setStagePosition(self, x: float=None, y: float=None, z: float=None, a: float=None,
-                         b: float=None, wait: bool=True, speed: float=1.0) -> None:
-        """Set the Stageposition x, y, z in microns and alpha(a), beta(b) in degs."""
+    def setStagePosition(
+            self,
+            x: Optional[int_nm] = None,
+            y: Optional[int_nm] = None,
+            z: Optional[int_nm] = None,
+            a: Optional[float_deg] = None,
+            b: Optional[float_deg] = None,
+            wait: bool = True,
+            speed: float = 1.0,
+    ) -> None:
+        """Set `Stageposition`'s x, y, z in m (from nm), alpha, beta in deg."""
         pos = self._tem.Stage.Position
         axis = 0
         enable_stage = False

--- a/instamaticServer/TEMController/typing.py
+++ b/instamaticServer/TEMController/typing.py
@@ -1,0 +1,6 @@
+from typing import Tuple
+
+
+int_nm = int  # Length expressed in nanometers
+float_deg = float  # Angle expressed in degrees
+StagePositionTuple = Tuple[int_nm, int_nm, int_nm, float_deg, float_deg]

--- a/instamaticServer/tem_server.py
+++ b/instamaticServer/tem_server.py
@@ -6,14 +6,14 @@ import signal
 import traceback
 import logging
 
-from TEMController.microscope import Microscope
+from TEMController.microscope import get_microscope
 from serializer import dumper, loader
 from utils.config import config
 
 condition = threading.Condition()
 stop_program_event = threading.Event()
 
-box = []
+box = []\
 
 _conf = config()
 HOST = _conf.default_settings['tem_server_host']
@@ -44,7 +44,7 @@ class TemServer(threading.Thread):
 
     def run(self):
         """Start the server thread."""
-        self.tem = Microscope(name=self._name)
+        self.tem = get_microscope(name=self._name)
         self._name = self.tem.name
         print("Initialized connection to microscope: %s" % (self._name))
 

--- a/instamaticServer/tem_server.py
+++ b/instamaticServer/tem_server.py
@@ -13,7 +13,7 @@ from utils.config import config
 condition = threading.Condition()
 stop_program_event = threading.Event()
 
-box = []\
+box = []
 
 _conf = config()
 HOST = _conf.default_settings['tem_server_host']


### PR DESCRIPTION
### The context

Currently, instamatic uses multiple different types to handle stage position variables. Stage length coordinates x, y, z are sometimes expressed as `int` in nanometers (Jeol microscope), sometimes as `float` in microns (FEI microscopes); sometimes, the same values are also supplied as neither `int` nor `float` but rather their numpy counterparts. This is especially harmful for a server without `numpy` such as Tecnai's that is unable to convert `numpy.int32` to `int`. Similarly, even though documentation suggests the angles should always be instances of `int` (though this is also not very clear), in numerous places the angles are instances of `float`.

This PR aims to unify the units used to express the position of microscope stage across instamatic. To this aim, it firstly introduces two new Annotated types: `int_nm` and `float_deg`. In python-3.4-based Tecnai server, these types are simply aliases `int` and `float` i.e. `type(int_nm(1.0)) == int`. The sole purpose of the new annotated wrappers is to display the unit in type hints in addition to the comments.

### Major changes
- `TecnaiMicroscope`'s `get`/`setStagePosition` now communicate distances in nanometers instead of microns, making their behavior consistent with the rest of Instamatic.

### Minor changes
- Whenever there is a room for any ambiguity, x/y/z & a/b are now hinted to be of `int_nm` & `float_deg` type;
  - In python 3.4 `Annotated` is not available, so these are just aliases of (equal to) `int` and `float`.
- Functions in `TEMController.microscope.py` were renamed to align with `instamatic.microscope.microscope.py`;
- `setStagePosition` input x/y/z/a/b input is now correctly marked as `typing.Optional`;
- `getStagePosition` and `setStagePosition` methods now hint that the return an instance of `StagePositionTuple` – which in case of Tecnai server is just a regular tuple that will be converted to named tuple by the client.


### Compatibility note
This PR is accompanied by and should be merged alongside PR #109 of Instamatic.