### PR TITLE
Fix inconsistent `speed` behavior of `setStagePosition`

### DIFF
--- a/instamaticServer/TEMController/tecnai_stage_thread.py
+++ b/instamaticServer/TEMController/tecnai_stage_thread.py
@@ -35,7 +35,7 @@ class TecnaiStageThread(threading.Thread):
             self._speed = 1.0
         
     def run(self) -> None:
-        #run only on the alpha-axis
+        # Note – Tecnai's `GoToWithSpeed` can only set one axis at time
         if self._pos is None:
             return
         with ContextManagedComtypes() as cmc:
@@ -54,6 +54,8 @@ class TecnaiStageThread(threading.Thread):
             if self._speed == 1.0:
                 self._tem.Stage.GoTo(stagePos, self._axis)
             else:
+                if self._axis & (self._axis - 1) != 0:  # equivalent to axis != 2**N
+                    raise RuntimeError('`GoToWithSpeed` can set only one axis at time.')
                 self._tem.Stage.GoToWithSpeed(stagePos, self._axis, self._speed)
 
 class ContextManagedComtypes():


### PR DESCRIPTION
### The context

When testing my experiment last week, I noticed that there are some inconsistencies in how the Tecnai server handles speed. After setting the rotation speed to 0.1 and calling `stage.set.a`, the stage still moved with speed 1.0. I found that the behavior of `TecnaiMicroscope.setStagePosition` is somewhat inconsistent, not to say buggy. For interested and posterity, the full behavior matrix before and after this PR is available [here](https://docs.google.com/spreadsheets/d/1DSIl2MFlQyAA77kH57zbIsliUtrIU_whnceD4hxfvZY/edit?usp=sharing); below, I discuss only the most crucial details and changes.

![image](https://github.com/user-attachments/assets/39be0148-7285-4d5e-adb5-1c86012a1e53)

Issue 1: in asynchronous execution i.e. if `wait=False`, `setRotationSpeed` and resulting `self._rotation_speed` are completely ignored. This happens because `setStagePosition` can pull speed from two different sources:  `speed` argument (higher priority) and `self._rotation_speed` attribute (lower priority). However, `setStagePosition`'s `speed` has no sentinel value: it is = 1 by default. Consequently, if you request `setStagePosition` without specifying speed, it will default to 1 instead of looking for previously set `_rotation_speed`. If you *do* specify the `speed`, the method moves the stage with `speed` as expected.

Issue 2: despite `setStagePosition`'s `speed` having no sentinel value, `speed = 1.0` is selectively treated as such. In particular, if you run exactly the same code as in Issue 1 but *synchronously* i.e. with `wait=True`, suddenly `speed = 1.0` is interpreted as "speed has not been set" and `self._rotation_speed` is used instead. This is incredibly confusing since the rotation speed of the stage will change depending if you wait for the stage or not.

I have addressed issues 1 and 2 by adding a new sentinel value for `setStagePosition`: now – in addition to usual float – `speed` can be set to `None` (new default). `Speed == None` signifies that speed was not specified and as such a fallback value should be used: `self._rotation_speed` for alpha rotation and 1.0 for other movement. Calling `setStagePosition(speed=1.0)` now *always* means that you want a full speed possible - the value of 1.0 is no longer ambiguous.

Finally, I noticed that for some reason `TecnaiStageThread` which handles asynchronous stage movement does not allow to asynchronously move anything else than alpha. I believe the reason behind that is Tecnai does not allow to call `GoToWithSpeed` with more than one axis at time. I see no reason why should we prevent one from moving "x" or "y" with speed though, I confirmed it does work, so I allowed these movements and added explicit errors instead of `pass` whenever impossible command is issued.

After this PR handling of the stage movement speed becomes more consistent and now follows set rules:
- If `speed` is specified and valid, use it; otherwise or if `None`, fall back to `self.rotation_speed` for alpha or 1.0 for others;
- The behavior and speed of `setStagePosition(wait=False)` and `setStagePosition(wait=True)` is now fully consistent;
- If an impossible command is issued, raise `RuntimeError` with a helpful message instead of passing silently.

### Minor changes
- In instamatic, calling `ctrl.stage.set_with_speed(*args, speed=1.0)` now always results in movement with full speed instead of occasionally moving with `self._rotation_speed` (and occasionally not).

### Bugfixes
- Behavior of `setStagePosition` is now consistent and properly obeys `self._rotation_speed` in asynchronous setting.